### PR TITLE
Some fixes

### DIFF
--- a/genki_signals/buffers.py
+++ b/genki_signals/buffers.py
@@ -200,7 +200,28 @@ class DataBuffer(MutableMapping, Buffer):
 
     @classmethod
     def from_dataframe(cls, df, maxlen=None):
-        return cls(maxlen=maxlen, data={k: df[k].values for k in df.columns})
+        split = re.compile(r"(?P<name>\D+)_(?P<number>(\d+)(_\d+)?(_\d+)?)")
+        data = {}
+        composite_data = {}
+        for col in df.columns:
+            m = split.match(col)
+            if m is not None:
+                name, number = m.groupdict()['name'], m.groupdict()['number']
+                number = tuple(map(int, number.split("_")))
+                if name not in composite_data:
+                    composite_data[name] = []
+                composite_data[name].append((number, df[col].values))
+            else:
+                data[col] = df[col].values
+        for name, values in composite_data.items():
+            values = sorted(values, key=lambda x: x[0])
+            pt_shape = tuple(d+1 for d in values[-1][0])
+            t_shape = values[0][1].shape
+            arr = np.zeros((*pt_shape, *t_shape), dtype=values[0][1].dtype)
+            for idx, pts in values:
+                arr[idx] = pts
+            data[name] = arr
+        return cls(maxlen=maxlen, data=data)
 
     def to_dataframe(self):
         flat_data = {}

--- a/genki_signals/functions/windowed.py
+++ b/genki_signals/functions/windowed.py
@@ -151,4 +151,5 @@ __all__ = [
     "SampleRate",
     "FourierTransform",
     "Delay",
+    "WindowedSignalFunction"
 ]

--- a/genki_signals/recorders.py
+++ b/genki_signals/recorders.py
@@ -104,3 +104,4 @@ class ParquetFileRecorder(DataFrameRecorder):
             df.to_parquet(self.path, index=False)
         else:
             df.to_parquet(self.path, mode="a", index=False)
+            

--- a/genki_signals/recorders.py
+++ b/genki_signals/recorders.py
@@ -61,7 +61,7 @@ class WavFileRecorder(Recorder):
         self.wavefile.close()
 
 
-class CsvFileRecorder(Recorder):
+class DataFrameRecorder(Recorder):
     def __init__(self, path, rec_buffer_size=1_000_000):
         self.path = path
         self.rec_buffer_size = rec_buffer_size
@@ -71,11 +71,15 @@ class CsvFileRecorder(Recorder):
     def _flush_to_file(self):
         df = self._recording_buffer.to_dataframe()
         if self._has_written_file:
-            df.to_csv(self.path, mode="a", header=False, index=False)
+            self.serialize_frame(df, initial_frame=False)
         else:
-            df.to_csv(self.path, index=False)
+            self.serialize_frame(df, initial_frame=True)
             self._has_written_file = True
         self._recording_buffer.clear()
+
+    @abc.abstractmethod
+    def serialize_frame(self, frame, initial_frame=False):
+        pass
 
     def write(self, data: DataBuffer):
         self._recording_buffer.extend(data)
@@ -84,3 +88,19 @@ class CsvFileRecorder(Recorder):
 
     def stop(self):
         self._flush_to_file()
+
+
+class CsvFileRecorder(DataFrameRecorder):
+    def serialize_frame(self, df, initial_frame=False):
+        if initial_frame:
+            df.to_csv(self.path, index=False)
+        else:
+            df.to_csv(self.path, mode="a", header=False, index=False)
+
+
+class ParquetFileRecorder(DataFrameRecorder):
+    def serialize_frame(self, df, initial_frame=False):
+        if initial_frame:
+            df.to_parquet(self.path, index=False)
+        else:
+            df.to_parquet(self.path, mode="a", index=False)

--- a/genki_signals/session.py
+++ b/genki_signals/session.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from pathlib import Path
 
 import numpy as np
+import pandas as pd
 
 from genki_signals.buffers import DataBuffer
 from genki_signals.functions.serialization import encode_signal_fn, decode_signal_fn
@@ -102,6 +103,10 @@ class Session:
             wavefile = wave.open(self.raw_data_path.as_posix(), "rb")
             data = wavefile.readframes(wavefile.getnframes())
             self._raw_data = DataBuffer(data={"audio": np.frombuffer(data, np.int16)})
+        elif self.datafile_extension == ".parquet":
+            self._raw_data = DataBuffer.from_dataframe(pd.read_parquet(self.raw_data_path))
+        elif self.datafile_extension == ".csv":
+            self._raw_data = DataBuffer.from_dataframe(pd.read_csv(self.raw_data_path))
         else:
             raise NotImplementedError(f"Loading data from {self._datafile_extension} is not implemented")
 

--- a/genki_signals/system.py
+++ b/genki_signals/system.py
@@ -19,7 +19,6 @@ class System:
     specified in Hz. Note that the update_rate will not be exact, as it is limited by the
     use of time.sleep(), so an error of up to 15% is expected.
     """
-
     def __init__(self, source, functions=None, update_rate=25):
         self.source = source
         self.functions = [] if functions is None else functions
@@ -42,6 +41,8 @@ class System:
             time.sleep(1 / self.update_rate)
 
     def register_data_feed(self, feed_id, callback):
+        if feed_id in self.data_feeds:
+            raise ValueError(f"Feed with id {feed_id} already exists")
         self.data_feeds[feed_id] = callback
 
     def deregister_data_feed(self, feed_id):

--- a/setup.py
+++ b/setup.py
@@ -48,4 +48,3 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
     ],
 )
-

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setuptools.setup(
     author="Genki Instruments",
     author_email="genki@genkiinstruments.com",
     keywords = ["Signal Processing", "Machine Learning", "Realtime"],
-    packages=setuptools.find_packages(exclude=("tests", "examples")),
+    packages=setuptools.find_packages(exclude=("tests", "test", "examples")),
     classifiers = [
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setuptools.setup(
     author="Genki Instruments",
     author_email="genki@genkiinstruments.com",
     keywords = ["Signal Processing", "Machine Learning", "Realtime"],
+    packages=setuptools.find_packages(exclude=("tests", "examples")),
     classifiers = [
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",

--- a/setup.py
+++ b/setup.py
@@ -48,3 +48,4 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
     ],
 )
+


### PR DESCRIPTION
* Make `from_dataframe` parse columns with dimensional names and stacks them to nd signals, to be consistent with `to_dataframe`
* Add `ParquetFileRecorder` and allow reading raw session data from csv and parquet
* Throw error if one tries to register a data feed to existing id without deregistering the other one first
* Make `pip install .` work